### PR TITLE
Two origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # cfs3
 
 Fun with cloud front and s3
+
+* basics - single bucket origin

--- a/doubledown/README.md
+++ b/doubledown/README.md
@@ -1,0 +1,5 @@
+aws cloudformation create-stack \
+--stack-name cf1 \
+--template-body file://doubledown.yml \
+--parameters ParameterKey=BucketNameOne,ParameterValue=foo97068one \
+ParameterKey=BucketNameTwo,ParameterValue=foo97068two

--- a/doubledown/doubledown.yml
+++ b/doubledown/doubledown.yml
@@ -1,0 +1,87 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Create a cloudfront distribution to distribute bucket contents, with no
+  direct access to the bucket allowed.
+
+Parameters:
+  BucketNameOne:
+    Type: String
+  BucketNameTwo:
+    Type: String
+
+Resources:
+  CFOriginIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: 'CF Id for Double DOwn'
+
+  ContentBucketOne:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketNameOne
+      AccessControl: BucketOwnerFullControl
+
+  ContentBucketTwo:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketNameTwo
+      AccessControl: BucketOwnerFullControl
+
+
+  ContentBucketPolicyOne:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ContentBucketOne
+      PolicyDocument:
+        Statement:
+        - Sid: CFreader
+          Effect: Allow
+          Principal:
+            'CanonicalUser': !GetAtt [CFOriginIdentity, S3CanonicalUserId]
+          Action: s3:GetObject
+          Resource: !Join [ '', ['arn:aws:s3:::', !Ref 'ContentBucketOne', /*]]
+
+  ContentBucketPolicyTwo:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ContentBucketTwo
+      PolicyDocument:
+        Statement:
+        - Sid: CFreader
+          Effect: Allow
+          Principal:
+            'CanonicalUser': !GetAtt [CFOriginIdentity, S3CanonicalUserId]
+          Action: s3:GetObject
+          Resource: !Join [ '', ['arn:aws:s3:::', !Ref 'ContentBucketTwo', /*]]
+
+
+  MyDistro:
+    Type: AWS::CloudFront::Distribution
+    DependsOn:
+    - ContentBucketOne
+    - ContentBucketTwo
+    Properties:
+      DistributionConfig:
+        Origins:
+        - DomainName: !Join [., [!Ref 'BucketNameOne', 's3.amazonaws.com']]
+          Id: contentBucketOriginOne
+          S3OriginConfig:
+            OriginAccessIdentity: !Join [/, ['origin-access-identity/cloudfront', !Ref 'CFOriginIdentity']]
+        - DomainName: !Join [., [!Ref 'BucketNameTwo', 's3.amazonaws.com']]
+          Id: contentBucketOriginTwo
+          S3OriginConfig:
+            OriginAccessIdentity: !Join [/, ['origin-access-identity/cloudfront', !Ref 'CFOriginIdentity']]
+        Enabled: 'true'
+        Comment: Two buckets are better than one
+        DefaultCacheBehavior:
+          DefaultTTL: 300
+          MinTTL: 0
+          MaxTTL: 600
+          ForwardedValues:
+            QueryString: 'false'
+            Cookies:
+              Forward: none
+          TargetOriginId: contentBucketOriginOne
+          ViewerProtocolPolicy: redirect-to-https
+        PriceClass: PriceClass_100

--- a/doubledown/doubledown.yml
+++ b/doubledown/doubledown.yml
@@ -8,6 +8,12 @@ Parameters:
     Type: String
   BucketNameTwo:
     Type: String
+  ActiveOrigin:
+    Type: String
+    Default: one
+    AllowedValues:
+      - one
+      - two
 
 Resources:
   CFOriginIdentity:
@@ -65,11 +71,11 @@ Resources:
       DistributionConfig:
         Origins:
         - DomainName: !Join [., [!Ref 'BucketNameOne', 's3.amazonaws.com']]
-          Id: contentBucketOriginOne
+          Id: one
           S3OriginConfig:
             OriginAccessIdentity: !Join [/, ['origin-access-identity/cloudfront', !Ref 'CFOriginIdentity']]
         - DomainName: !Join [., [!Ref 'BucketNameTwo', 's3.amazonaws.com']]
-          Id: contentBucketOriginTwo
+          Id: two
           S3OriginConfig:
             OriginAccessIdentity: !Join [/, ['origin-access-identity/cloudfront', !Ref 'CFOriginIdentity']]
         Enabled: 'true'
@@ -82,6 +88,6 @@ Resources:
             QueryString: 'false'
             Cookies:
               Forward: none
-          TargetOriginId: contentBucketOriginOne
+          TargetOriginId: !Ref 'ActiveOrigin'
           ViewerProtocolPolicy: redirect-to-https
         PriceClass: PriceClass_100

--- a/doubledown/one.html
+++ b/doubledown/one.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h3>one</h3>
+</body>
+</html>

--- a/doubledown/two.html
+++ b/doubledown/two.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h3>two</h3>
+</body>
+</html>


### PR DESCRIPTION
Added sample that has a CF distribution with two s3 origins, which a short caching policy and a stack parameter that allows toggling the active origin. This would support a very basic blue/green content deployment scenario.